### PR TITLE
modify code to get rid of deprecation warnings

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -1,7 +1,27 @@
 from SublimeLinter.lint import Linter
 
 
-class Mdl(Linter):
+class RubyLinter(Linter):
+    def context_sensitive_executable_path(self, cmd):
+        # The default implementation will look for a user defined `executable`
+        # setting.
+        success, executable = super().context_sensitive_executable_path(cmd)
+        if success:
+            return True, executable
+
+        gem_name = cmd[0] if isinstance(cmd, list) else cmd
+
+        if self.settings.get('use_bundle_exec', False):
+            return True, ['bundle', 'exec', gem_name]
+
+        rvm = self.which('rvm-auto-ruby')
+        if rvm:
+            return True, [rvm, '-S', gem_name]
+
+        return False, None
+
+
+class Mdl(RubyLinter):
     cmd = ['mdl', '${temp_file}']
     regex = r'^.+?:(?P<line>\d+): (?P<warning>(?P<message>[^`]*))'
     line_col_base = (1, 1)

--- a/linter.py
+++ b/linter.py
@@ -1,8 +1,8 @@
-from SublimeLinter.lint import RubyLinter
+from SublimeLinter.lint import Linter
 
 
-class Mdl(RubyLinter):
-    executable = 'mdl'
+class Mdl(Linter):
+    cmd= ['mdl', '${temp_file}']
     regex = r'^.+?:(?P<line>\d+): (?P<warning>(?P<message>[^`]*))'
     line_col_base = (1, 1)
     tempfile_suffix = 'md'
@@ -10,9 +10,3 @@ class Mdl(RubyLinter):
         'selector': 'text.html.markdown'
     }
 
-    def cmd(self):
-        """Support bundle-exec."""
-
-        if self.get_view_settings().get('bundle-exec', False):
-            return ('bundle', 'exec', self.executable)
-        return (self.executable_path)

--- a/linter.py
+++ b/linter.py
@@ -2,11 +2,10 @@ from SublimeLinter.lint import Linter
 
 
 class Mdl(Linter):
-    cmd= ['mdl', '${temp_file}']
+    cmd = ['mdl', '${temp_file}']
     regex = r'^.+?:(?P<line>\d+): (?P<warning>(?P<message>[^`]*))'
     line_col_base = (1, 1)
     tempfile_suffix = 'md'
     defaults = {
         'selector': 'text.html.markdown'
     }
-


### PR DESCRIPTION
Hi,
I get some deprecation warnings in the console by installing the mdl linter:

```
SublimeLinter: WARNING: mdl: `self.get_view_settings()` has been deprecated.  Just use the member `self.settings` which is the same thing.
SublimeLinter: WARNING: mdl: `executable_path` has been deprecated. Just use an ordinary binary name instead. 
SublimeLinter: WARNING: mdl: Implicit appending a filename to `cmd` has been deprecated, add '${temp_file}' explicitly.
```

So, to get rid of them, I modified the code a bit. It runs fine on my installation. Additionally, I changed the linter class to tackle issue #5. I don't see any benefits of using RubyLinter instead of Linter. However, maybe there are reasons for your choice, but in issue #5, it seems you're open-minded to change that. 

Best, 
Sandro